### PR TITLE
Add demo categories and extend helloworld endpoints

### DIFF
--- a/DEMO_CATEGORIES.md
+++ b/DEMO_CATEGORIES.md
@@ -1,0 +1,84 @@
+# Demo分类
+
+该仓库包含多个 Spring Boot 示例，为便于查找和学习，按功能划分为以下几类：
+
+## 入门基础
+- demo-helloworld
+- demo-properties
+
+## 日志与监控
+- demo-actuator
+- demo-admin-client
+- demo-admin-server
+- demo-logback
+- demo-log-aop
+- demo-exception-handler
+- demo-graylog
+
+## 模板引擎
+- demo-template-freemarker
+- demo-template-thymeleaf
+- demo-template-beetl
+- demo-template-enjoy
+
+## 数据访问
+- demo-orm-jdbctemplate
+- demo-orm-jpa
+- demo-orm-mybatis
+- demo-orm-mybatis-mapper-page
+- demo-orm-mybatis-plus
+- demo-orm-beetlsql
+- demo-multi-datasource-jpa
+- demo-multi-datasource-mybatis
+- demo-sharding-jdbc
+- demo-dynamic-datasource
+
+## 缓存与存储
+- demo-cache-redis
+- demo-cache-ehcache
+- demo-upload
+- demo-mongodb
+- demo-neo4j
+- demo-elasticsearch
+- demo-elasticsearch-rest-high-level-client
+
+## 消息与通信
+- demo-mq-rabbitmq
+- demo-mq-rocketmq
+- demo-mq-kafka
+- demo-websocket
+- demo-websocket-socketio
+
+## 安全与权限
+- demo-rbac-security
+- demo-rbac-shiro
+- demo-session
+- demo-oauth
+- demo-social
+- demo-ldap
+- demo-zookeeper
+- demo-ratelimit-guava
+- demo-ratelimit-redis
+
+## 任务调度
+- demo-task
+- demo-task-quartz
+- demo-task-xxl-job
+
+## 其他功能
+- demo-email
+- demo-swagger
+- demo-swagger-beauty
+- demo-async
+- demo-https
+- demo-war
+- demo-dubbo
+- demo-docker
+- demo-tio
+- demo-codegen
+- demo-uflo
+- demo-urule
+- demo-ureport2
+- demo-activiti
+- demo-flyway
+- demo-pay

--- a/demo-helloworld/README.md
+++ b/demo-helloworld/README.md
@@ -90,14 +90,36 @@ public class SpringBootDemoHelloworldApplication {
 	 * @param who 参数，非必须
 	 * @return Hello, ${who}
 	 */
-	@GetMapping("/hello")
-	public String sayHello(@RequestParam(required = false, name = "who") String who) {
-		if (StrUtil.isBlank(who)) {
-			who = "World";
-		}
-		return StrUtil.format("Hello, {}!", who);
-	}
-}
+         @GetMapping("/hello")
+         public String sayHello(@RequestParam(required = false, name = "who") String who) {
+                 if (StrUtil.isBlank(who)) {
+                         who = "World";
+                 }
+                 return StrUtil.format("Hello, {}!", who);
+         }
+
+         /**
+          * Goodbye，World
+          *
+          * @param who 参数，非必须
+          * @return Goodbye, ${who}
+          */
+         @GetMapping("/goodbye")
+         public String sayGoodbye(@RequestParam(required = false, name = "who") String who) {
+                 if (StrUtil.isBlank(who)) {
+                         who = "World";
+                 }
+                 return StrUtil.format("Goodbye, {}!", who);
+         }
+
+         /**
+          * 获取当前服务器时间
+          */
+         @GetMapping("/time")
+         public String currentTime() {
+                 return LocalDateTime.now().toString();
+         }
+  }
 ```
 
 ### application.yml

--- a/demo-helloworld/src/main/java/com/xkcoding/helloworld/SpringBootDemoHelloworldApplication.java
+++ b/demo-helloworld/src/main/java/com/xkcoding/helloworld/SpringBootDemoHelloworldApplication.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+
 /**
  * <p>
  * SpringBoot启动类
@@ -35,5 +37,29 @@ public class SpringBootDemoHelloworldApplication {
             who = "World";
         }
         return StrUtil.format("Hello, {}!", who);
+    }
+
+    /**
+     * Goodbye endpoint
+     *
+     * @param who optional name
+     * @return Goodbye message
+     */
+    @GetMapping("/goodbye")
+    public String sayGoodbye(@RequestParam(required = false, name = "who") String who) {
+        if (StrUtil.isBlank(who)) {
+            who = "World";
+        }
+        return StrUtil.format("Goodbye, {}!", who);
+    }
+
+    /**
+     * Get current server time.
+     *
+     * @return current time in ISO format
+     */
+    @GetMapping("/time")
+    public String currentTime() {
+        return LocalDateTime.now().toString();
     }
 }


### PR DESCRIPTION
## Summary
- document categories for all demos in `DEMO_CATEGORIES.md`
- extend helloworld demo with `/goodbye` and `/time` endpoints
- document new endpoints in demo README

## Testing
- `mvn -q test -pl demo-helloworld` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a82f9d1b88327bd029c70edac2c5e